### PR TITLE
Crashes track error

### DIFF
--- a/appcenter-crashes/CHANGELOG.md
+++ b/appcenter-crashes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.6.0
+
+### Features
+
+* **android**: Add `Crashes.trackError()` API to track handled errors in your app.
+* **ios**: Add `Crashes.trackError()` API stub, it's not supported for iOS yet.
+
 ## 0.5.0
 
 ### Features

--- a/appcenter-crashes/README.md
+++ b/appcenter-crashes/README.md
@@ -48,6 +48,7 @@ npx cap sync
 * [`hasReceivedMemoryWarningInLastSession()`](#hasreceivedmemorywarninginlastsession)
 * [`hasCrashedInLastSession()`](#hascrashedinlastsession)
 * [`lastSessionCrashReport()`](#lastsessioncrashreport)
+* [`trackError(...)`](#trackerror)
 * [Interfaces](#interfaces)
 
 </docgen-index>
@@ -146,6 +147,25 @@ Provides details about the crash that occurred in the last app session.
 --------------------
 
 
+### trackError(...)
+
+```typescript
+trackError(errorModel: TrackableErrorModel) => Promise<{ value: string; }>
+```
+
+Track error
+
+| Param            | Type                                                                |
+| ---------------- | ------------------------------------------------------------------- |
+| **`errorModel`** | <code><a href="#trackableerrormodel">TrackableErrorModel</a></code> |
+
+**Returns:** <code>Promise&lt;{ value: string; }&gt;</code>
+
+**Since:** 0.5.0
+
+--------------------
+
+
 ### Interfaces
 
 
@@ -184,5 +204,24 @@ Provides details about the crash that occurred in the last app session.
 | **`carrierCountry`** | <code>string</code> | Carrier country code (for mobile devices).                                                                                            |
 | **`appBuild`**       | <code>string</code> | The app's build number, e.g. 42.                                                                                                      |
 | **`appNamespace`**   | <code>string</code> | The bundle identifier, package identifier, or namespace, depending on what the individual plattforms use, .e.g com.microsoft.example. |
+
+
+#### TrackableErrorModel
+
+| Prop              | Type                                                              |
+| ----------------- | ----------------------------------------------------------------- |
+| **`error`**       | <code><a href="#exceptionmodeltype">ExceptionModelType</a></code> |
+| **`properties`**  | <code>{ [name: string]: string; }</code>                          |
+| **`attachments`** | <code>ErrorAttachmentLog[]</code>                                 |
+
+
+#### ExceptionModelType
+
+| Prop                 | Type                | Description                                        |
+| -------------------- | ------------------- | -------------------------------------------------- |
+| **`wrapperSdkName`** | <code>string</code> | Name of the wrapper SDK. e.g 'appcenter.capacitor' |
+| **`type`**           | <code>string</code> | Exception type, e.g 'TypeException'                |
+| **`message`**        | <code>string</code> | Exception message                                  |
+| **`stackTrace`**     | <code>string</code> | Exception stacktrace                               |
 
 </docgen-api>

--- a/appcenter-crashes/android/build.gradle
+++ b/appcenter-crashes/android/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 
 dependencies {
-    api 'com.microsoft.appcenter:appcenter-crashes:4.2.0'
+    api 'com.microsoft.appcenter:appcenter-crashes:4.3.1'
     api 'com.microsoft.appcenter.reactnative:appcenter-react-native:4.2.0' // change to own version
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')

--- a/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesBase.java
+++ b/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesBase.java
@@ -12,8 +12,15 @@ import java.util.Map;
 
 public class CrashesBase {
 
-  public String trackError(JSObject error, JSObject properties, JSArray attachments) {
-    Exception exceptionModel = CrashesUtil.toExceptionModel(error);
+  /**
+   * Track a handled custom exception
+   * @param exception - JSObject containing AppCenter crashes.ingestion.models.Exception properties
+   * @param properties - JSObject containing any custom properties for the exception
+   * @param attachments - JSArray containing objects of  to save with the exception
+   * @return
+   */
+  public String trackException(JSObject exception, JSObject properties, JSArray attachments) {
+    Exception exceptionModel = CrashesUtil.toExceptionModel(exception);
 
     Map<String, String> convertedProperties = null;
     if (properties != null) {
@@ -26,6 +33,33 @@ public class CrashesBase {
     }
 
     return WrapperSdkExceptionManager.trackException(exceptionModel, convertedProperties, convertedAttachments);
+  }
+
+  /**
+   * Track a handled error
+   * @param error Error to track
+   */
+  public void trackError(Throwable error) {
+    trackError(error, null, null);
+  }
+
+  /**
+   * Track a handled error with name and optional properties
+   * @param error Error to track
+   * @param properties
+   */
+  public void trackError(Throwable error, Map<String, String> properties) {
+    trackError(error, properties, null);
+  }
+
+  /**
+   * Track a handled error with name and optional properties and attachments.
+   * @param error
+   * @param properties 
+   * @param attachments
+   */
+  public void trackError(Throwable error, Map<String, String> properties, Iterable<ErrorAttachmentLog> attachments) {
+    Crashes.trackError(error, properties, attachments);
   }
 
   public void enable(boolean enabled) {

--- a/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesBase.java
+++ b/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesBase.java
@@ -1,9 +1,32 @@
 package com.getcapacitor.plugin.appcenter.crashes;
 
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
 import com.microsoft.appcenter.AppCenter;
 import com.microsoft.appcenter.crashes.Crashes;
+import com.microsoft.appcenter.crashes.WrapperSdkExceptionManager;
+import com.microsoft.appcenter.crashes.ingestion.models.ErrorAttachmentLog;
+import com.microsoft.appcenter.crashes.ingestion.models.Exception;
+
+import java.util.Map;
 
 public class CrashesBase {
+
+  public String trackError(JSObject error, JSObject properties, JSArray attachments) {
+    Exception exceptionModel = CrashesUtil.toExceptionModel(error);
+
+    Map<String, String> convertedProperties = null;
+    if (properties != null) {
+      convertedProperties = CrashesUtil.convertJSObjectToStringMap(properties);
+    }
+
+    Iterable<ErrorAttachmentLog> convertedAttachments = null;
+    if (attachments != null) {
+      convertedAttachments = CrashesUtil.toCustomErrorAttachments(attachments);
+    }
+
+    return WrapperSdkExceptionManager.trackException(exceptionModel, convertedProperties, convertedAttachments);
+  }
 
   public void enable(boolean enabled) {
     Crashes.setEnabled(enabled).get();

--- a/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesPlugin.java
+++ b/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesPlugin.java
@@ -12,7 +12,7 @@ import com.microsoft.appcenter.reactnative.shared.AppCenterReactNativeShared;
 @CapacitorPlugin(name = "Crashes")
 public class CrashesPlugin extends Plugin {
 
-    private CrashesBase implementation = new CrashesBase();
+    private final CrashesBase implementation = new CrashesBase();
 
     @Override
     public void load() {

--- a/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesPlugin.java
+++ b/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesPlugin.java
@@ -35,7 +35,7 @@ public class CrashesPlugin extends Plugin {
         }
 
         JSObject ret = new JSObject();
-        ret.put("errorReportId", errorReportId);
+        ret.put("value", errorReportId);
         call.resolve(ret);
     }
 

--- a/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesPlugin.java
+++ b/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesPlugin.java
@@ -28,7 +28,9 @@ public class CrashesPlugin extends Plugin {
 
         String errorReportId;
         try {
-            errorReportId = implementation.trackError(error, properties, attachments);
+            // We call trackException here and not trackError because the error is a custom error
+            // parsed from JS instead of a Throwable error. It ends up the same in AppCenter
+            errorReportId = implementation.trackException(error, properties, attachments);
         } catch (java.lang.Exception e) {
             call.reject("Exception while tracking error: " + e.getMessage());
             return;

--- a/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesPlugin.java
+++ b/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesPlugin.java
@@ -1,13 +1,12 @@
 package com.getcapacitor.plugin.appcenter.crashes;
 
+import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
-import com.microsoft.appcenter.AppCenter;
-import com.microsoft.appcenter.crashes.Crashes;
 import com.microsoft.appcenter.reactnative.shared.AppCenterReactNativeShared;
 
 @CapacitorPlugin(name = "Crashes")
@@ -19,6 +18,25 @@ public class CrashesPlugin extends Plugin {
     public void load() {
         AppCenterReactNativeShared.configureAppCenter(this.getActivity().getApplication());
         implementation.start();
+    }
+
+    @PluginMethod
+    public void trackError(PluginCall call) {
+        JSObject error = call.getObject("error");
+        JSObject properties = call.getObject("properties");
+        JSArray attachments = call.getArray("attachments");
+
+        String errorReportId;
+        try {
+            errorReportId = implementation.trackError(error, properties, attachments);
+        } catch (java.lang.Exception e) {
+            call.reject(e.getMessage());
+            return;
+        }
+
+        JSObject ret = new JSObject();
+        ret.put("errorReportId", errorReportId);
+        call.resolve(ret);
     }
 
     @PluginMethod(returnType = PluginMethod.RETURN_NONE)

--- a/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesUtil.java
+++ b/appcenter-crashes/android/src/main/java/com/getcapacitor/plugin/appcenter/crashes/CrashesUtil.java
@@ -1,0 +1,116 @@
+package com.getcapacitor.plugin.appcenter.crashes;
+
+import android.util.Base64;
+import android.util.Log;
+
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.microsoft.appcenter.crashes.ingestion.models.ErrorAttachmentLog;
+import com.microsoft.appcenter.crashes.ingestion.models.Exception;
+
+import org.json.JSONObject;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+
+/**
+ * Utility class containing helpers for converting App Center objects.
+ */
+public class CrashesUtil {
+    private static final String LOG_TAG = "AppCenterCrashes";
+    private static final String DATA_FIELD = "data";
+    private static final String TEXT_FIELD = "text";
+    private static final String FILE_NAME_FIELD = "fileName";
+    private static final String CONTENT_TYPE_FIELD = "contentType";
+
+    public static void logError(String message) {
+        Log.e(LOG_TAG, message);
+    }
+
+    static void logInfo(String message) {
+        Log.i(LOG_TAG, message);
+    }
+
+    static void logDebug(String message) {
+        Log.d(LOG_TAG, message);
+    }
+
+    /**
+     * Creates an AppCenter Exception model out of JSObject.
+     * Used for creating an actual Exception model out of passed in data from a plugin call from js.
+     * @param jsObject JSObject to convert
+     * @return AppCenter Exception model
+     */
+    public static Exception toExceptionModel(JSObject jsObject) {
+        Exception model = new Exception();
+        try {
+            model.read(jsObject);
+            if (model.getType() == null || model.getType().equals("")) {
+                throw new java.lang.Exception("Type value shouldn't be null or empty");
+            }
+            if (model.getMessage() == null || model.getMessage().equals("")) {
+                throw new java.lang.Exception("Message value shouldn't be null or empty");
+            }
+            if (model.getWrapperSdkName() == null || model.getWrapperSdkName().equals("")) {
+                throw new java.lang.Exception("wrapperSdkName value shouldn't be null or empty");
+            }
+        } catch (java.lang.Exception e) {
+            CrashesUtil.logError("Failed to get exception model");
+            CrashesUtil.logError(Log.getStackTraceString(e));
+        }
+        return model;
+    }
+
+    /**
+     * Converts JSObject to String Map
+     * @param jsObject JSObject to convert
+     * @return String map
+     */
+    public static Map<String, String> convertJSObjectToStringMap(JSObject jsObject) {
+        Map<String, String> stringMap = new HashMap<>();
+        if (jsObject != null) {
+            Iterator<String> keys = jsObject.keys();
+            while(keys.hasNext()) {
+                String key = keys.next();
+                String value = jsObject.getString(key);
+                stringMap.put(key, value);
+            }
+        }
+        return stringMap;
+    }
+
+    /**
+     * Creates a Collection of AppCenter ErrorAttachmentLog from a JSArray of attachment objects
+     * Used for extracting attachments from a plugin call from js to be able to upload it to AppCenter.
+     * @param attachments JSArray of attachment objects
+     * @return Collection of ErrorAttachmentLog
+     */
+    public static Collection<ErrorAttachmentLog> toCustomErrorAttachments(JSArray attachments) {
+        Collection<ErrorAttachmentLog> attachmentLogs = new LinkedList<>();
+        try {
+            for (int i = 0; i < attachments.length(); i++) {
+                JSONObject jsAttachment = attachments.getJSONObject(i);
+                String fileName = null;
+                if (jsAttachment.has(FILE_NAME_FIELD)) {
+                    fileName = jsAttachment.getString(FILE_NAME_FIELD);
+                }
+                if(jsAttachment.has(TEXT_FIELD)) {
+                    String text = jsAttachment.getString(TEXT_FIELD);
+                    attachmentLogs.add(ErrorAttachmentLog.attachmentWithText(text, fileName));
+                } else {
+                    String encodedData = jsAttachment.getString(DATA_FIELD);
+                    byte[] data = Base64.decode(encodedData, Base64.DEFAULT);
+                    String contentType = jsAttachment.getString(CONTENT_TYPE_FIELD);
+                    attachmentLogs.add(ErrorAttachmentLog.attachmentWithBinary(data, fileName, contentType));
+                }
+            }
+        } catch (java.lang.Exception e) {
+            CrashesUtil.logError("Failed to get error attachment for report: " + attachments);
+            CrashesUtil.logError(Log.getStackTraceString(e));
+        }
+        return attachmentLogs;
+    }
+}

--- a/appcenter-crashes/ios/Plugin/AppCenterCrashesPlugin.m
+++ b/appcenter-crashes/ios/Plugin/AppCenterCrashesPlugin.m
@@ -4,6 +4,7 @@
 // Define the plugin using the CAP_PLUGIN Macro, and
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(CrashesPlugin, "Crashes",
+           CAP_PLUGIN_METHOD(trackError, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setEnabled, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(isEnabled, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(generateTestCrash, CAPPluginReturnNone);

--- a/appcenter-crashes/ios/Plugin/AppCenterCrashesPlugin.swift
+++ b/appcenter-crashes/ios/Plugin/AppCenterCrashesPlugin.swift
@@ -23,6 +23,16 @@ public class CrashesPlugin: CAPPlugin {
             implementation.start()
         }
     }
+    
+    @objc func trackError(_ call: CAPPluginCall) {
+        // The trackError functionality is missing in the AppCenter SDK for iOS
+        // See: https://github.com/microsoft/appcenter/issues/192
+        //
+        // It would maybe be possible to upload straight to AppCenter with a REST api like here
+        // https://github.com/microsoft/appcenter/issues/192#issuecomment-698187673
+        // https://docs.microsoft.com/en-us/appcenter/diagnostics/upload-crashes#upload-an-error-report
+        call.unimplemented("Not yet supported on iOS");
+    }
 
     @objc func setEnabled(_ call: CAPPluginCall) {
         implementation.enable(call.getBool("shouldEnable") ?? false)

--- a/appcenter-crashes/package.json
+++ b/appcenter-crashes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/appcenter-crashes",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Capacitor plugin for Microsoft's App Center Crashes",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/appcenter-crashes/src/definitions.ts
+++ b/appcenter-crashes/src/definitions.ts
@@ -135,6 +135,37 @@ export class ErrorAttachmentLog {
   }
 }
 
+export class ExceptionModel {
+    wrapperSdkName = 'appcenter.capacitor';
+    type: string;
+    message: string;
+    stackTrace?: string;
+
+    constructor(type: string, message: string, stackTrace?: string) {
+        this.type = type;
+        this.message = message;
+        this.stackTrace = stackTrace;
+    }
+
+    public static createFromError(error: Error): ExceptionModel {
+        return new this(error.name, error.message, error.stack);
+    }
+
+    public static createFromTypeAndMessage(
+        type: string,
+        message: string,
+        stackTrace?: string
+      ): ExceptionModel {
+        return new this(type, message, stackTrace);
+      }
+}
+
+export interface TrackableErrorModel {
+    error: ExceptionModel;
+    properties?: { [name: string]: string };
+    attachments?: ErrorAttachmentLog[];
+}
+
 export interface CrashesPlugin {
   /**
    * Check if Crashes is enabled or not.
@@ -201,6 +232,25 @@ export interface CrashesPlugin {
      * const { value: crashReport } = await Crashes.lastSessionCrashReport();
      */
     lastSessionCrashReport(): Promise<{value: ErrorReport}>;
+
+    /**
+     * Track error
+     * @returns {Promise<{ errorReportId: string }>}
+     * @since 0.5.0
+     * @example
+     * import Crashes, { ExceptionModel, ErrorAttachmentLog } from '@capacitor-community/appcenter-crashes';
+     *
+     * const error = ExceptionModel.createFromError(new Error("test error"));
+     * const attachments = [
+     *  ErrorAttachmentLog.attachmentWithText("some text", "testfile.txt"),
+     * ]
+     * const { errorReportId } = await Crashes.trackError({
+     *  error,
+     *  properties: { testProp: 'testVal' },
+     *  attachments,
+     * });
+     */
+    trackError(errorModel: TrackableErrorModel): Promise<{ errorReportId: string }>;
 }
 
 // convert

--- a/appcenter-crashes/src/definitions.ts
+++ b/appcenter-crashes/src/definitions.ts
@@ -135,7 +135,25 @@ export class ErrorAttachmentLog {
   }
 }
 
-export class ExceptionModel {
+export interface ExceptionModelType {
+    /**
+     * Name of the wrapper SDK. e.g 'appcenter.capacitor'
+     */
+    wrapperSdkName: string;
+    /**
+     * Exception type, e.g 'TypeException'
+     */
+    type: string;
+    /**
+     * Exception message
+     */
+    message: string;
+    /**
+     * Exception stacktrace
+     */
+    stackTrace?: string;
+}
+export class ExceptionModel implements ExceptionModelType {
     wrapperSdkName = 'appcenter.capacitor';
     type: string;
     message: string;
@@ -161,7 +179,7 @@ export class ExceptionModel {
 }
 
 export interface TrackableErrorModel {
-    error: ExceptionModel;
+    error: ExceptionModelType;
     properties?: { [name: string]: string };
     attachments?: ErrorAttachmentLog[];
 }

--- a/appcenter-crashes/src/definitions.ts
+++ b/appcenter-crashes/src/definitions.ts
@@ -261,7 +261,7 @@ export interface CrashesPlugin {
     /**
      * Track error
      * @returns {Promise<{ errorReportId: string }>}
-     * @since 0.5.0
+     * @since 0.6.0
      * @example
      * import Crashes, { ExceptionModel, ErrorAttachmentLog } from '@capacitor-community/appcenter-crashes';
      *

--- a/appcenter-crashes/src/definitions.ts
+++ b/appcenter-crashes/src/definitions.ts
@@ -244,13 +244,13 @@ export interface CrashesPlugin {
      * const attachments = [
      *  ErrorAttachmentLog.attachmentWithText("some text", "testfile.txt"),
      * ]
-     * const { errorReportId } = await Crashes.trackError({
+     * const { value } = await Crashes.trackError({
      *  error,
      *  properties: { testProp: 'testVal' },
      *  attachments,
      * });
      */
-    trackError(errorModel: TrackableErrorModel): Promise<{ errorReportId: string }>;
+    trackError(errorModel: TrackableErrorModel): Promise<{ value: string }>;
 }
 
 // convert

--- a/appcenter-crashes/src/web.ts
+++ b/appcenter-crashes/src/web.ts
@@ -3,7 +3,7 @@ import { WebPlugin } from '@capacitor/core';
 import type { CrashesPlugin, ErrorReport } from './definitions';
 
 export class CrashesWeb extends WebPlugin implements CrashesPlugin {
-  trackError(): Promise<{ errorReportId: string }> {
+  trackError(): Promise<{ value: string }> {
     throw this.unimplemented('Not supported on web.');
   }
   lastSessionCrashReport(): Promise<{ value: ErrorReport }> {

--- a/appcenter-crashes/src/web.ts
+++ b/appcenter-crashes/src/web.ts
@@ -1,23 +1,24 @@
 import { WebPlugin } from '@capacitor/core';
 
-import { CrashesPlugin, ErrorReport } from './definitions';
+import type { CrashesPlugin, ErrorReport } from './definitions';
 
-export class CrashesWeb
-  extends WebPlugin
-  implements CrashesPlugin {
-  lastSessionCrashReport(): Promise<{ value: ErrorReport; }> {
-    throw new Error('Method not implemented.');
-  }
-  hasCrashedInLastSession(): Promise<{ value: boolean; }> {
+export class CrashesWeb extends WebPlugin implements CrashesPlugin {
+  trackError(): Promise<{ errorReportId: string }> {
     throw this.unimplemented('Not supported on web.');
   }
-  hasReceivedMemoryWarningInLastSession(): Promise<{ value: boolean; }> {
+  lastSessionCrashReport(): Promise<{ value: ErrorReport }> {
+    throw this.unimplemented('Not supported on web.');
+  }
+  hasCrashedInLastSession(): Promise<{ value: boolean }> {
+    throw this.unimplemented('Not supported on web.');
+  }
+  hasReceivedMemoryWarningInLastSession(): Promise<{ value: boolean }> {
     throw this.unimplemented('Not supported on web.');
   }
   generateTestCrash(): Promise<void> {
     throw this.unimplemented('Not supported on web.');
   }
-  isEnabled(): Promise<{ value: boolean; }> {
+  isEnabled(): Promise<{ value: boolean }> {
     throw this.unimplemented('Not supported on web.');
   }
   setEnabled(): Promise<void> {

--- a/example/package.json
+++ b/example/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@capacitor-community/appcenter": "^0.7.0",
     "@capacitor-community/appcenter-analytics": "^0.3.0",
-    "@capacitor-community/appcenter-crashes": "^0.5.0",
+    "@capacitor-community/appcenter-crashes": "^0.6.0",
     "@capacitor/android": "^3.0.0",
     "@capacitor/app": "^1.0.0",
     "@capacitor/cli": "^3.0.0",

--- a/example/src/components/app-crashes/app-crashes.tsx
+++ b/example/src/components/app-crashes/app-crashes.tsx
@@ -1,6 +1,6 @@
 import { Component, State, h } from '@stencil/core';
 import { ToggleChangeEventDetail } from '@ionic/core';
-import Crashes, { ErrorReport } from '@capacitor-community/appcenter-crashes';
+import Crashes, { ErrorReport, ExceptionModel, ErrorAttachmentLog } from '@capacitor-community/appcenter-crashes';
 
 @Component({
   tag: 'app-crashes',
@@ -12,6 +12,14 @@ export class AppCrashes {
   @State() memoryWarning: boolean = false
   @State() hasCrashed: boolean = false
   @State() crashReport: ErrorReport
+  /* Track error fields */
+  @State() errorType: string = "";
+  @State() errorMessage: string = "";
+  @State() propertyName: string = "";
+  @State() propertyValue: string = "";
+  @State() attachmentText: string = "";
+  @State() attachmentName: string = "";
+
 
   constructor() {
     this.toggleCrashes = this.toggleCrashes.bind(this);
@@ -49,7 +57,20 @@ export class AppCrashes {
     try {
       await Crashes.generateTestCrash()
     } catch (error) {
-      
+
+    }
+  }
+
+  async trackError() {
+    try {
+      const error = ExceptionModel.createFromTypeAndMessage(this.errorType, this.errorMessage);
+      const properties = { [this.propertyName]: this.propertyValue };
+      const attachments = [
+        ErrorAttachmentLog.attachmentWithText(this.attachmentText, this.attachmentName)
+      ];
+      await Crashes.trackError({ error, properties, attachments });
+    } catch (error) {
+      console.error(error)
     }
   }
 
@@ -82,6 +103,40 @@ export class AppCrashes {
           </ion-item>
         </ion-list>
 
+        <ion-list lines="full" class="ion-no-margin">
+          <ion-list-header lines="full">
+            <ion-label>
+              Track Error
+            </ion-label>
+          </ion-list-header>
+          <ion-item>
+            <ion-label position="stacked">Error type</ion-label>
+            <ion-input disabled={!this.enabled} placeholder="Error" value={this.errorType} onIonChange={e => {this.errorType = e.detail.value}}></ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-label position="stacked">Error message</ion-label>
+            <ion-input disabled={!this.enabled} placeholder="'number' cannot be null" value={this.errorMessage} onIonChange={e => {this.errorMessage = e.detail.value}}></ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-label position="stacked">Property Name</ion-label>
+            <ion-input disabled={!this.enabled} placeholder="category" value={this.propertyName} onIonChange={e => {this.propertyName = e.detail.value}}></ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-label position="stacked">Property Value</ion-label>
+            <ion-input disabled={!this.enabled} placeholder="music" value={this.propertyValue} onIonChange={e => {this.propertyValue = e.detail.value}}></ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-label position="stacked">Attachment Name</ion-label>
+            <ion-input disabled={!this.enabled} placeholder="attachment.txt" value={this.attachmentName} onIonChange={e => {this.attachmentName = e.detail.value}}></ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-label position="stacked">Attachment Text</ion-label>
+            <ion-input disabled={!this.enabled} placeholder="Additional text for error" value={this.attachmentText} onIonChange={e => {this.attachmentText = e.detail.value}}></ion-input>
+          </ion-item>
+        </ion-list>
+        <br/>
+        <ion-button disabled={!this.enabled} onClick={this.trackError} expand="block">Track Error</ion-button>
+
         <section>
           <header>Generate a Test Crash</header>
           <ion-button color="danger" expand="block" onClick={this.crashApp}>Let app crash</ion-button>
@@ -97,7 +152,6 @@ export class AppCrashes {
               <ion-label>{key}</ion-label>
             </ion-item>
           }) : null}
-          
         </ion-list>
 
       </ion-content>,


### PR DESCRIPTION
Hey, I hope this helps. I noticed when adding this that the `trackError` functionality is unfortunately not supported by AppCenter for iOS 😦 
https://github.com/microsoft/appcenter/issues/192
I added a stub for iOS in the meantime

* Added trackError plugin method for android
* Added trackError plugin method stub for ios (not currently supported by AppCenter SDK)
* Added trackError to method interface in ts
* Added example for Crashes.trackError