### PR TITLE
Crashes track error ios

### DIFF
--- a/appcenter-analytics/CHANGELOG.md
+++ b/appcenter-analytics/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Change Log
 
 ## 0.3.1
+
+### Fixes
+
+* **ios**
+  * Update plugin method name `enable` to `setEnabled`
+
+### Chores
  
-**ios**
-* Update `Appcenter/Analytics` to 4.3.0
-* Update `AppCenterCapacitorShared` to 0.3.2
+* **ios**
+  * Update `Appcenter/Analytics` to 4.3.0
+  * Update `AppCenterCapacitorShared` to 0.3.2
 
 ## 0.3.0
 
@@ -12,9 +19,10 @@
 
 ## 0.2.1
 
-* Update `Appcenter/Analytics` to 4.2.0
-* Update `AppCenterCapacitorShared` to 0.3.1
 * Update `docgen` to 0.0.17
+* **ios**
+  * Update `Appcenter/Analytics` to 4.2.0
+  * Update `AppCenterCapacitorShared` to 0.3.1
 
 ### Fixes
  * correct void return type methods (iOS)

--- a/appcenter-analytics/CHANGELOG.md
+++ b/appcenter-analytics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.3.1
+ 
+**ios**
+* Update `Appcenter/Analytics` to 4.3.0
+* Update `AppCenterCapacitorShared` to 0.3.2
+
 ## 0.3.0
 
 * add support for Android

--- a/appcenter-analytics/CapacitorCommunityAppcenterAnalytics.podspec
+++ b/appcenter-analytics/CapacitorCommunityAppcenterAnalytics.podspec
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '12.0'
   s.dependency 'Capacitor'
-  s.dependency 'AppCenterCapacitorShared', '0.3.1'
-  s.dependency 'AppCenter/Analytics', '4.2.0'
+  s.dependency 'AppCenterCapacitorShared', '0.3.2'
+  s.dependency 'AppCenter/Analytics', '4.3.0'
   s.static_framework = true
   s.swift_version = '5.1'
 end

--- a/appcenter-analytics/ios/Plugin/AppCenterAnalyticsPlugin.m
+++ b/appcenter-analytics/ios/Plugin/AppCenterAnalyticsPlugin.m
@@ -4,7 +4,7 @@
 // Define the plugin using the CAP_PLUGIN Macro, and
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(AnalyticsPlugin, "Analytics",
-           CAP_PLUGIN_METHOD(enable, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(setEnabled, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(isEnabled, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(pause, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(resume, CAPPluginReturnNone);

--- a/appcenter-analytics/ios/Plugin/AppCenterAnalyticsPlugin.swift
+++ b/appcenter-analytics/ios/Plugin/AppCenterAnalyticsPlugin.swift
@@ -31,7 +31,7 @@ public class AnalyticsPlugin: CAPPlugin {
         }
     }
     
-    @objc func enable(_ call: CAPPluginCall) {
+    @objc func setEnabled(_ call: CAPPluginCall) {
         implementation.enable(call.getBool("enableFlag") ?? false)
         call.resolve()
     }

--- a/appcenter-analytics/ios/Podfile
+++ b/appcenter-analytics/ios/Podfile
@@ -9,8 +9,8 @@ end
 
 target 'Plugin' do
   capacitor_pods
-  pod 'AppCenterCapacitorShared', '0.3.1'
-  pod 'AppCenter/Analytics', '4.2.0'
+  pod 'AppCenterCapacitorShared', '0.3.2'
+  pod 'AppCenter/Analytics', '4.3.0'
 end
 
 target 'PluginTests' do

--- a/appcenter-analytics/package.json
+++ b/appcenter-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/appcenter-analytics",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Capacitor plugin for AppCenter Analytics",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/appcenter-crashes/CHANGELOG.md
+++ b/appcenter-crashes/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.7.0
+
+### Features
+
+* **ios**: 
+    * Update `AppCenter/Crashes` to 4.3.0
+    * Update `AppCenterCapacitorShared` to 0.3.2
+    * Implement `Crashes.trackError()` API after AppCenter/Crashes update
+
 ## 0.6.0
 
 ### Features

--- a/appcenter-crashes/CapacitorCommunityAppcenterCrashes.podspec
+++ b/appcenter-crashes/CapacitorCommunityAppcenterCrashes.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.1'
   s.static_framework = true
   s.dependency 'Capacitor'
-  s.dependency 'AppCenterCapacitorShared', '0.3.1'
-  s.dependency 'AppCenter/Crashes', '4.2.0'
+  s.dependency 'AppCenterCapacitorShared', '0.3.2'
+  s.dependency 'AppCenter/Crashes', '4.3.0'
 end

--- a/appcenter-crashes/README.md
+++ b/appcenter-crashes/README.md
@@ -161,7 +161,7 @@ Track error
 
 **Returns:** <code>Promise&lt;{ value: string; }&gt;</code>
 
-**Since:** 0.5.0
+**Since:** 0.6.0
 
 --------------------
 

--- a/appcenter-crashes/ios/Plugin/AppCenterCrashesBase.swift
+++ b/appcenter-crashes/ios/Plugin/AppCenterCrashesBase.swift
@@ -5,10 +5,13 @@ import AppCenterCrashes
 
 @objc public class AppCenterCrashesBase: NSObject {
     
-    public func trackException(_ exceptionObject: JSObject?, _ propertiesObject: JSObject?, _ attachmentsObject: JSArray?) throws -> String {
-        let exception = try CrashesUtil.toExceptionModel(exceptionObject)
+    public func trackException(_ exceptionObject: JSObject?, _ propertiesObject: JSObject?, _ attachmentsArray: [JSObject]?) throws -> String {
+        let exceptionModel = try CrashesUtil.toExceptionModel(exceptionObject)
+        let properties = propertiesObject as? [String: String] ?? nil
+        let attachments = CrashesUtil.toErrorAttachmentLogs(attachmentsArray ?? [])
         
-        return Crashes.trackException(exception, properties: nil, attachments: nil)
+        
+        return Crashes.trackException(exceptionModel, properties: properties, attachments: attachments)
     }
     
     public func trackError(_ error: Error, _ properties: [String: String]?, _ attachments: [ErrorAttachmentLog]?) {

--- a/appcenter-crashes/ios/Plugin/AppCenterCrashesBase.swift
+++ b/appcenter-crashes/ios/Plugin/AppCenterCrashesBase.swift
@@ -4,6 +4,16 @@ import AppCenter
 import AppCenterCrashes
 
 @objc public class AppCenterCrashesBase: NSObject {
+    
+    public func trackException(_ exceptionObject: JSObject?, _ propertiesObject: JSObject?, _ attachmentsObject: JSArray?) throws -> String {
+        let exception = try CrashesUtil.toExceptionModel(exceptionObject)
+        
+        return Crashes.trackException(exception, properties: nil, attachments: nil)
+    }
+    
+    public func trackError(_ error: Error, _ properties: [String: String]?, _ attachments: [ErrorAttachmentLog]?) {
+        Crashes.trackError(error, properties: properties, attachments: attachments)
+    }
    
     public func enable(_ flag: Bool) {
         Crashes.enabled = flag

--- a/appcenter-crashes/ios/Plugin/AppCenterCrashesPlugin.swift
+++ b/appcenter-crashes/ios/Plugin/AppCenterCrashesPlugin.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Capacitor
 import AppCenterCapacitorShared
-import AppCenterCrashes
 
 @objc(CrashesPlugin)
 public class CrashesPlugin: CAPPlugin {

--- a/appcenter-crashes/ios/Plugin/AppCenterCrashesPlugin.swift
+++ b/appcenter-crashes/ios/Plugin/AppCenterCrashesPlugin.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Capacitor
 import AppCenterCapacitorShared
+import AppCenterCrashes
 
 @objc(CrashesPlugin)
 public class CrashesPlugin: CAPPlugin {
@@ -25,13 +26,22 @@ public class CrashesPlugin: CAPPlugin {
     }
     
     @objc func trackError(_ call: CAPPluginCall) {
-        // The trackError functionality is missing in the AppCenter SDK for iOS
-        // See: https://github.com/microsoft/appcenter/issues/192
-        //
-        // It would maybe be possible to upload straight to AppCenter with a REST api like here
-        // https://github.com/microsoft/appcenter/issues/192#issuecomment-698187673
-        // https://docs.microsoft.com/en-us/appcenter/diagnostics/upload-crashes#upload-an-error-report
-        call.unimplemented("Not yet supported on iOS");
+        DispatchQueue.main.async {
+            let errorToTrack = call.getObject("error")
+            let properties = call.getObject("properties")
+            let attachments = call.getArray("attachments")
+            
+            do {
+                // We call trackException here and not trackError because the error is a custom exception
+                // parsed from JS instead of a Throwable error
+                let errorReportId = try self.implementation.trackException(errorToTrack, properties, attachments);
+                call.resolve(["value": errorReportId])
+            } catch CrashesUtil.ExceptionModelError.validationError(let message) {
+                call.reject("Tracking error failed: \(message)")
+            } catch {
+                call.reject("Tracking error failed: \(error)")
+            }
+        }
     }
 
     @objc func setEnabled(_ call: CAPPluginCall) {

--- a/appcenter-crashes/ios/Plugin/AppCenterCrashesPlugin.swift
+++ b/appcenter-crashes/ios/Plugin/AppCenterCrashesPlugin.swift
@@ -29,7 +29,7 @@ public class CrashesPlugin: CAPPlugin {
         DispatchQueue.main.async {
             let errorToTrack = call.getObject("error")
             let properties = call.getObject("properties")
-            let attachments = call.getArray("attachments")
+            let attachments = call.getArray("attachments", JSObject.self)
             
             do {
                 // We call trackException here and not trackError because the error is a custom exception

--- a/appcenter-crashes/ios/Plugin/AppCenterCrashesUtil.swift
+++ b/appcenter-crashes/ios/Plugin/AppCenterCrashesUtil.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Capacitor
 import AppCenterCrashes
 
 /**
@@ -21,6 +22,36 @@ public class CrashesUtil {
     static let kMSCarrierCountry: String = "carrierCountry";
     static let kMSAppBuild: String = "appBuild";
     static let kMSAppNamespace: String = "appNamespace";
+    
+    enum ExceptionModelError: Error {
+        case validationError(_ message: String)
+    }
+    
+    public static func toExceptionModel(_ jsObject: JSObject?) throws -> MSACWrapperExceptionModel {
+        if (jsObject == nil) {
+            throw ExceptionModelError.validationError("Exception model cannot be nil")
+        }
+        
+        let model = MSACWrapperExceptionModel()
+        
+        if (jsObject?["type"] == nil || jsObject?["type"] as? String == "") {
+            throw ExceptionModelError.validationError("Type value shouldn't be nil or empty")
+        }
+        if (jsObject?["message"] == nil || jsObject?["message"] as? String == "") {
+            throw ExceptionModelError.validationError("Message value shouldn't be nil or empty")
+        }
+        if (jsObject?["wrapperSdkName"] == nil || jsObject?["wrapperSdkName"] as? String == "") {
+            throw ExceptionModelError.validationError("wrapperSdkName value shouldn't be nil or empty")
+        }
+        model.type = jsObject?["type"] as? String
+        model.message = jsObject?["message"] as? String
+        model.wrapperSdkName = jsObject?["wrapperSdkName"] as? String
+        if (jsObject?["stackTrace"] != nil) {
+            model.stackTrace = jsObject?["stackTrace"] as? String
+        }
+        
+        return model
+    }
    
     /**
      Serializes App Center Device properties to Dictionary
@@ -105,7 +136,7 @@ public class CrashesUtil {
     */
    public static func convertReportsToJS (reports: [ErrorReport]) -> [[String: Any]] {
        var jsReadyReports = [[String: Any]]()
-       for (index, value) in reports.enumerated() {
+       for (_, value) in reports.enumerated() {
            guard let convertedReport = convertReportToJs(report: value) else {
                continue
            }

--- a/appcenter-crashes/ios/Podfile
+++ b/appcenter-crashes/ios/Podfile
@@ -9,8 +9,8 @@ end
 
 target 'Plugin' do
   capacitor_pods
-  pod 'AppCenterCapacitorShared', '0.3.1'
-  pod 'AppCenter/Crashes', '4.2.0'
+  pod 'AppCenterCapacitorShared', '0.3.2'
+  pod 'AppCenter/Crashes', '4.3.0'
 end
 
 target 'PluginTests' do

--- a/appcenter-crashes/package.json
+++ b/appcenter-crashes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/appcenter-crashes",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Capacitor plugin for Microsoft's App Center Crashes",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/appcenter-crashes/src/definitions.ts
+++ b/appcenter-crashes/src/definitions.ts
@@ -261,7 +261,7 @@ export interface CrashesPlugin {
     /**
      * Track error
      * @returns {Promise<{ errorReportId: string }>}
-     * @since 0.5.0
+     * @since 0.6.0
      * @example
      * import Crashes, { ExceptionModel, ErrorAttachmentLog } from '@capacitor-community/appcenter-crashes';
      *

--- a/appcenter/CHANGELOG.md
+++ b/appcenter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.7.1](https://github.com/capacitor-community/appcenter-sdk-capacitor/compare/@capacitor-community/appcenter@0.6.0...@capacitor-community/appcenter@0.7.1)
+
+### Chores
+
+* **ios**: Bump `AppCenterCapacitorShared` version to `0.3.2`
+
 ## [0.7.0](https://github.com/capacitor-community/appcenter-sdk-capacitor/compare/@capacitor-community/appcenter@0.6.0...@capacitor-community/appcenter@0.7.0)
 
 ### Features

--- a/appcenter/CapacitorCommunityAppcenter.podspec
+++ b/appcenter/CapacitorCommunityAppcenter.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '12.0'
   s.dependency 'Capacitor'
-  s.dependency 'AppCenterCapacitorShared', '0.3.1'
+  s.dependency 'AppCenterCapacitorShared', '0.3.2'
   s.static_framework = true
   s.swift_version = '5.1'
 end

--- a/appcenter/ios/Podfile
+++ b/appcenter/ios/Podfile
@@ -9,7 +9,7 @@ end
 
 target 'Plugin' do
   capacitor_pods
-  pod 'AppCenterCapacitorShared', '0.3.1'
+  pod 'AppCenterCapacitorShared', '0.3.2'
 end
 
 target 'PluginTests' do

--- a/appcenter/package.json
+++ b/appcenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/appcenter",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Capacitor Plugin for Microsoft's App Center SDK.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/example/package.json
+++ b/example/package.json
@@ -19,9 +19,9 @@
     "@stencil/core": "^2.8.0"
   },
   "dependencies": {
-    "@capacitor-community/appcenter": "^0.7.0",
-    "@capacitor-community/appcenter-analytics": "^0.3.0",
-    "@capacitor-community/appcenter-crashes": "^0.6.0",
+    "@capacitor-community/appcenter": "^0.7.1",
+    "@capacitor-community/appcenter-analytics": "^0.3.1",
+    "@capacitor-community/appcenter-crashes": "^0.7.0",
     "@capacitor/android": "^3.0.0",
     "@capacitor/app": "^1.0.0",
     "@capacitor/cli": "^3.0.0",

--- a/example/src/components/app-crashes/app-crashes.tsx
+++ b/example/src/components/app-crashes/app-crashes.tsx
@@ -26,6 +26,7 @@ export class AppCrashes {
   constructor() {
     this.toggleCrashes = this.toggleCrashes.bind(this);
     this.crashApp = this.crashApp.bind(this);
+    this.trackError = this.trackError.bind(this);
   }
 
   async componentWillLoad() {


### PR DESCRIPTION
Hey 😄 finally we have trackError for iOS as well 🚀 

I had to update the `AppCenter/*` and `AppCenterCapacitorShared` pod versions in all three packages so the example would build

### @capacitor-community/appcenter-crashes
* Implemented `Crashes.trackError` method for iOS
* Added `trackError` base methods for iOS and Android (they're not used, but could be used)
* Updated `AppCenter/Crashes` pod to `4.3.0`
* Updated `AppCenterCapacitorShared` pod to `0.3.2`
* Bumped version number from `0.6.0` to `0.7.0`

### @capacitor-community/appcenter-analytics
* Updated `AppCenter/Analytics` pod to `4.3.0`
* Updated `AppCenterCapacitorShared` pod to `0.3.2`
* Bumped version number from `0.3.0` to `0.3.1`
* Change `enable` method name to `setEnabled`

### @capacitor-community/appcenter
* Updated `AppCenter/Core` pod to `4.3.0`
* Updated `AppCenterCapacitorShared` pod to `0.3.2`
* Bumped version number from `0.7.0` to `0.7.1`